### PR TITLE
[CI][A13] a13-5.10 security date 2024-04

### DIFF
--- a/.github/workflows/build-kernel-a13.yml
+++ b/.github/workflows/build-kernel-a13.yml
@@ -54,6 +54,9 @@ jobs:
           - version: "5.10"
             sub_level: 205
             os_patch_level: 2024-02
+          - version: "5.10"
+            sub_level: 205
+            os_patch_level: 2024-03
           - version: "5.15"
             sub_level: 41
             os_patch_level: 2022-11


### PR DESCRIPTION
I accidentally deleted the branch for the previous PR(#1471), thanks tiann for the Makefile link

My Pixel 7a March 2024 update has kernel version 5.10.189-android13-4-00012-g1217bb583cc5-ab11174560 and Android security update 2024-03

https://cs.android.com/android/kernel/superproject/+/common-android13-5.10-2024-03:common/Makefile

Thanks